### PR TITLE
feat: add dependabot group support for commitlint packages

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -11,4 +11,4 @@ rules:
     'revert',
     'test'
   ]]
-  scope-empty: [0, 'never']
+scope-empty: [1, 'always']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,9 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "build"
+    groups:
+      commitlint:
+        applies-to: version-updates
+        dependency-type: "development"
+        patterns:
+          - "@commitlint*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       },
       "engines": {
         "node": "22",
-        "npm": "10"
+        "npm": ">=10"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "homepage": "https://github.com/ukhsa-collaboration/standards-template",
   "license": "MIT",
   "engines": {
-    "npm": "10",
+    "npm": ">=10",
     "node": "22"
   },
   "devDependencies": {


### PR DESCRIPTION
@commitlint/cli and @commitlint/config-conventional should be updated together

- update commitlintrc.yaml to prevent the usage of scope in commit message
- update package.json engines to allow newer npm versions